### PR TITLE
ENG-173660: Add docs for include_bio param in agent#index

### DIFF
--- a/source/partials/public_api/api_usage/agent/index.md.erb
+++ b/source/partials/public_api/api_usage/agent/index.md.erb
@@ -183,6 +183,7 @@ Attribute | Type  | Length Limit |
 |<span class="optional-data">has_company_programs</span>|<span class="data-type">Boolean</span>| 255 |
 |<span class="optional-data">include_reviews</span>|<span class="data-type">Boolean</span>| 255 |
 |<span class="optional-data">timestamps_only</span>|<span class="data-type">Boolean</span>| 255 |
+|<span class="optional-data">include_bio</span>|<span class="data-type">Boolean</span>| 255 |
 
 <span class="required-data">**Required Parameters Are In Red**</span>
 
@@ -234,6 +235,9 @@ Attribute | Type  | Length Limit |
 
 <span class="request-data-head">timestamps_only</span>
 <span class="request-data-remarks">If supplied then the results will exclude all data except primary identifiers and a unix timestamp (last_updated) & iso8601 timestamp (modification_timestamp) of the last time this record was updated.</span>
+
+<span class="request-data-head">include_bio</span>
+<span class="request-data-remarks">To include bio  associated with the agent in the response, pass `true`.</span>
 
 <blockquote><div class='highlight json' style="display: block">
 <span class="data-example-label">Agent Index: Success Response</span>


### PR DESCRIPTION
## Description

- Updated api docs for agent#index endpoint to include `include_bio` param info

## JIRA Link
https://moxiworks.atlassian.net/browse/ENG-173660

## Validation Steps
https://moxiworks-platform.github.io/api.html#agent-index should include `include_bio` param as well.

## PR Checklist
Please ensure steps below have been completed before creating your PR

- [x] A relevant title is added and prefixed with the JIRA ticket number
- [x] Detailed description provided
- [x] JIRA link updated with ticket number
- [x] Validation steps clearly outlined
- [x] Locally tested by the author (if not, explain why)
- [ ] Test coverage (if not, explain why)
- [x] Diff is easy to follow (add clarifying comments where needed)
