### PR TITLE
ENG-180644: Add logo_url to office endpoint docs

### DIFF
--- a/source/partials/public_api/api_usage/office/index.md.erb
+++ b/source/partials/public_api/api_usage/office/index.md.erb
@@ -182,7 +182,8 @@ Attribute | Type  | Length Limit |
     "mailing_state":"UM",
     "company_programs": [
         "Equestrian Equestrian Advisor"
-     ]
+     ],
+    "logo_url": "http://the.office.logo/image.png"
   }
   ]
 }
@@ -245,6 +246,7 @@ Attribute | Type |
 |<span class="response-data">created_timestamp</span>|<span class="data-type">Integer</span>|
 |<span class="response-data">deactivated_timestamp</span>|<span class="data-type">Integer or null</span>|
 |<span class="response-data">company_programs</span>|<span class="data-type">Array</span>|
+|<span class="response-data">logo_url</span>|<span class="data-type">String</span>|
 
 <span class="response-data-head">moxi_works_office_id</span>
 <span class="response-data-remarks">This is the MoxiWorks Platform ID of the office for this <span class='entity-name'>Office</span>. This will be an [RFC 4122](https://tools.ietf.org/html/rfc4122) compliant UUID.</span>
@@ -340,3 +342,6 @@ Attribute | Type |
 
 <span class="response-data-head">company_programs</span>
 <span class="response-data-remarks">A list of the company specific program names in which the agent's office participates or is a member.</span>
+
+<span class="response-data-head">logo_url</span>
+<span class="response-data-remarks">URL of the office logo image. This can be null if there is no data for this attribute.</span>

--- a/source/partials/public_api/api_usage/office/show.md.erb
+++ b/source/partials/public_api/api_usage/office/show.md.erb
@@ -128,7 +128,8 @@ Attribute | Type  | Length Limit |
     "mailing_state":"UM",
     "company_programs": [
         "Equestrian Equestrian Advisor"
-      ]
+      ],
+    "logo_url": "http://the.office.logo/image.png"
   }
 
 ```
@@ -178,6 +179,7 @@ Attribute | Type |
 |<span class="response-data">created_timestamp</span>|<span class="data-type">Integer</span>|
 |<span class="response-data">deactivated_timestamp</span>|<span class="data-type">Integer or null</span>|
 |<span class="response-data">company_programs</span>|<span class="data-type">Array</span>|
+|<span class="response-data">logo_url</span>|<span class="data-type">String</span>|
 
 <span class="response-data-head">moxi_works_office_id</span>
 <span class="response-data-remarks">This is the MoxiWorks Platform ID of the office for this <span class='entity-name'>Office</span>. This will be an [RFC 4122](https://tools.ietf.org/html/rfc4122) compliant UUID.</span>
@@ -272,3 +274,6 @@ Attribute | Type |
 
 <span class="response-data-head">company_programs</span>
 <span class="response-data-remarks">A list of the company specific program names in which the agent's office participates or is a member.</span>
+
+<span class="response-data-head">logo_url</span>
+<span class="response-data-remarks">URL of the office logo image. This can be null if there is no data for this attribute.</span>


### PR DESCRIPTION
## Description

- updated office controller docs to reflect changes made by ENG-146213

## JIRA Link
https://moxiworks.atlassian.net/browse/ENG-180644

## Validation Steps
https://moxiworks-platform.github.io/api.html#office-show and https://moxiworks-platform.github.io/api.html#office-index should include `logo_url` in the response examples.

## PR Checklist
Please ensure steps below have been completed before creating your PR

- [x] A relevant title is added and prefixed with the JIRA ticket number
- [x] Detailed description provided
- [x] JIRA link updated with ticket number
- [x] Validation steps clearly outlined
- [x] Locally tested by the author (if not, explain why)
- [ ] Test coverage (if not, explain why)
- [x] Diff is easy to follow (add clarifying comments where needed)